### PR TITLE
Fix for adapter registration with zope.interface >= 5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Changelog
 0.9.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- zope.interface >= 5.0 adapter registration fix [petschki]
 
 
 0.9.9 (2020-05-05)

--- a/src/plone/jsonserializer/deserializer/converters.py
+++ b/src/plone/jsonserializer/deserializer/converters.py
@@ -74,12 +74,17 @@ def default_converter(value, field):
 @adapter(Interface, IBool)
 @implementer(ISchemaCompatible)
 def bool_converter(value, field):
+    # since zope.interface >= 5.0 we never get here ... see below from_unicode_converter
     return bool(value)
 
 
 @adapter(Interface, IFromUnicode)
 @implementer(ISchemaCompatible)
 def from_unicode_converter(value, field):
+    # zope.schema.Bool fields also provide IFromUnicode
+    # since zope.interface >= 5.0 we get this adapter for boolean fields
+    if isinstance(value, bool):
+        value = str(value)
     try:
         return field.fromUnicode(value)
     except UnicodeEncodeError:


### PR DESCRIPTION
Since zope.interface >= 5.0 the IFromUnicode adapter wins over the IBool because zope.schema.Bool also provides IFromUnicode ... 